### PR TITLE
Fix mobile viewport centering and add touch-region controls

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <main>
+  <main @touchstart.prevent="handleScreenTap">
     <Board
       :cell-size=cellSize
       :width=width
@@ -38,22 +38,57 @@ export default {
   },
   created() {
     initLevel(this);
+  },
 
-    window.addEventListener('load', (e) => {
-      // TODO: Forbid manual scroll and hide scrollers
-      scrollToPoint(this.heroX, this.heroY, this.cellSize);
-    });
+  mounted() {
+    this.centerOnHero();
+    window.addEventListener('keydown', this.handleKeydown);
+  },
 
-    window.addEventListener('keydown', (e) => {
-      // TODO: Prevent only arrow keys actions
-      e.preventDefault();
-      processKey(e.key, this);
-    });
+  beforeUnmount() {
+    window.removeEventListener('keydown', this.handleKeydown);
   },
 
   methods: {
+    centerOnHero() {
+      this.$nextTick(() => {
+        requestAnimationFrame(() => {
+          scrollToPoint(this.heroX, this.heroY, this.cellSize);
+        });
+      });
+    },
+
+    handleKeydown(e) {
+      if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
+        return;
+      }
+
+      e.preventDefault();
+      processKey(e.key, this);
+    },
+
     handleClick(key) {
       processKey(key, this);
+    },
+
+    handleScreenTap(e) {
+      if (!e.touches || !e.touches.length) return;
+
+      const touch = e.touches[0];
+      const viewportWidth = window.innerWidth;
+      const viewportHeight = window.innerHeight;
+      const x = touch.clientX;
+      const y = touch.clientY;
+
+      const distances = [
+        { key: 'ArrowLeft', value: x },
+        { key: 'ArrowRight', value: viewportWidth - x },
+        { key: 'ArrowUp', value: y },
+        { key: 'ArrowDown', value: viewportHeight - y },
+      ];
+
+      distances.sort((a, b) => a.value - b.value);
+      processKey(distances[0].key, this);
     }
   },
 }
@@ -62,4 +97,8 @@ export default {
 
 <style>
 @import './assets/base.css';
+
+main {
+  touch-action: none;
+}
 </style>

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -28,41 +28,38 @@ function processCell(data) {
 }
 
 function processKey(key, data) {
-    console.log(key);
+    let isMoved = false;
     switch(key) {
         case 'ArrowRight':
             if (isCellEmpty(data.field, data.width, data.height, data.heroX + 1, data.heroY)) {
                 data.heroX += 1;
-                if (data.heroX > consts.INIT_SIGHT + 1) {
-                    window.scrollBy(data.cellSize, 0);
-                }
+                isMoved = true;
             }
         break;
         case 'ArrowLeft':
             if (isCellEmpty(data.field, data.width, data.height, data.heroX - 1, data.heroY)) {
                 data.heroX -= 1;
-                if (data.heroX < (data.width - consts.INIT_SIGHT - 2)) {
-                    window.scrollBy(-data.cellSize, 0);
-                }
+                isMoved = true;
             }
         break;
         case 'ArrowUp':
             if (isCellEmpty(data.field, data.width, data.height, data.heroX, data.heroY - 1)) {
                 data.heroY -= 1;
-                if (data.heroY < (data.height - consts.INIT_SIGHT - 2)) {
-                    window.scrollBy(0, -data.cellSize);
-                }
+                isMoved = true;
             }
         break;
         case 'ArrowDown':
             if (isCellEmpty(data.field, data.width, data.height, data.heroX, data.heroY + 1)) {
                 data.heroY += 1;
-                if (data.heroY > consts.INIT_SIGHT + 1) {
-                    window.scrollBy(0, data.cellSize);
-                }
+                isMoved = true;
             }
         break;
     }
+
+    if (isMoved) {
+        scrollToPoint(data.heroX, data.heroY, data.cellSize);
+    }
+
     // console.log(data.heroX, data.heroY);
     data.stepCtr++;
     decreaseSight(data);


### PR DESCRIPTION
### Motivation
- Mobile users reported the viewport not centering on the hero at load and inconsistent follow-scrolling while moving.  
- The mobile control should map screen taps to directions (left/right/up/down) based on visible viewport area instead of mapping to a specific cell.

### Description
- Move initial centering to `mounted()` and run after render using `this.$nextTick()` + `requestAnimationFrame()` to reliably center the viewport on the hero (`src/App.vue`).
- Replace incremental `window.scrollBy(...)` logic with a deterministic re-center call using `scrollToPoint(...)` after any successful move in `processKey` (`src/game/engine.js`).
- Add touch handling on the main game surface to map a tap to a direction by computing proximity to screen edges and invoke `processKey(...)` with `ArrowLeft`/`ArrowRight`/`ArrowUp`/`ArrowDown` based on the nearest edge (`src/App.vue`).
- Restrict keyboard handling to arrow keys only, keep existing click-to-move behavior, and disable default touch gestures on the game surface via `touch-action: none` to reduce native scrolling interference (`src/App.vue`).

### Testing
- Ran the production build with `npm run build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfebf74d1c8323a6c564438b7e02cd)