### PR TITLE
End-of-level flow: portal dialog, map reveal, soul-track and progress persistence

### DIFF
--- a/skills/frontend-endlevel-flow/SKILL.md
+++ b/skills/frontend-endlevel-flow/SKILL.md
@@ -1,0 +1,15 @@
+# frontend-endlevel-flow
+
+## Purpose
+Use this skill when changing end-of-level UX in the maze game.
+
+## Workflow
+1. Update `src/App.vue` for state transitions (`finish -> modal -> reveal -> next level`).
+2. Update `src/components/Board.vue` to render reveal-only overlays.
+3. Update `src/game/engine.js` only for movement/progress persistence logic.
+4. Keep rendering concerns in Vue components and storage/game-state concerns in engine.
+
+## Verification
+- Run `npm run build`.
+- Manually verify there is no blocking browser `alert` in finish flow.
+- Ensure overlay elements are `pointer-events: none` unless interactive by design.

--- a/skills/project-checks/SKILL.md
+++ b/skills/project-checks/SKILL.md
@@ -1,0 +1,13 @@
+# project-checks
+
+## Purpose
+Consistent local validation before commit for this Vue/Vite repository.
+
+## Commands
+1. `npm run build`
+2. `git status --short`
+3. `git diff -- src/App.vue src/components/Board.vue src/game/engine.js`
+
+## Notes
+- If UI changed, capture screenshot when browser tooling is available.
+- Include any environment limitation in final report with a warning symbol.

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,26 @@
 <template>
-  <main>
+  <main :class="{ 'main--revealed': mapRevealed }">
     <Board
-      :cell-size=cellSize
-      :width=width
-      :height=height
-      :field=field
-      :hero-x=heroX
-      :hero-y=heroY
-      :hero-sight=heroSight
-      :hero-image=heroImage
+      :cell-size="cellSize"
+      :width="width"
+      :height="height"
+      :field="field"
+      :hero-x="heroX"
+      :hero-y="heroY"
+      :hero-sight="heroSight"
+      :hero-image="heroImage"
+      :reveal-map="mapRevealed"
+      :soul-track="soulTrack"
+      :show-soul-track="mapRevealed"
     />
+    <button
+      v-if="mapRevealed"
+      class="carry-on"
+      type="button"
+      @click="carryOn"
+    >
+      Carry on
+    </button>
   </main>
   <teleport to="body">
     <div v-if="showMovePad" class="move-pad" :style="movePadStyle" aria-label="Movement controls">
@@ -46,9 +57,40 @@
         <span class="move-pad__arrow move-pad__arrow--down"></span>
       </button>
     </div>
+
+    <div v-if="showPortalDialog" class="portal-dialog-backdrop">
+      <div class="portal-dialog" role="dialog" aria-modal="true" aria-label="Level complete">
+        <svg class="portal-dialog__svg" viewBox="0 0 520 260" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <defs>
+            <linearGradient id="dialogFrame" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#66d9ff" stop-opacity="0.95" />
+              <stop offset="100%" stop-color="#8d79ff" stop-opacity="0.95" />
+            </linearGradient>
+            <linearGradient id="dialogFill" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#111b2f" stop-opacity="0.95" />
+              <stop offset="100%" stop-color="#0b1324" stop-opacity="0.95" />
+            </linearGradient>
+          </defs>
+          <rect x="8" y="8" width="504" height="244" rx="22" fill="url(#dialogFill)" stroke="url(#dialogFrame)" stroke-width="4" />
+          <rect x="24" y="24" width="472" height="212" rx="16" fill="none" stroke="rgba(180,223,255,0.45)" stroke-dasharray="10 8" />
+          <circle cx="73" cy="64" r="15" fill="#99e9ff" fill-opacity="0.22" />
+          <circle cx="443" cy="80" r="12" fill="#b1a4ff" fill-opacity="0.3" />
+          <circle cx="460" cy="177" r="17" fill="#72ffe0" fill-opacity="0.2" />
+          <text x="260" y="98" text-anchor="middle" fill="#b8f0ff" font-size="32" font-family="Inter, sans-serif" font-weight="700">
+            Portal discovered
+          </text>
+          <text x="260" y="140" text-anchor="middle" fill="#f4f8ff" font-size="18" font-family="Inter, sans-serif">
+            Your soul remembers every step.
+          </text>
+          <text x="260" y="170" text-anchor="middle" fill="#c7d4ef" font-size="16" font-family="Inter, sans-serif">
+            Press OK to reveal the full map.
+          </text>
+        </svg>
+        <button type="button" class="portal-dialog__ok" @click="revealMap">OK</button>
+      </div>
+    </div>
   </teleport>
 </template>
-
 
 <script>
 import Board from './components/Board.vue'
@@ -71,6 +113,7 @@ export default {
       heroSight: -1,
       cellSize: consts.CELL_SIZE,
       stepCtr: 0,
+      soulTrack: {},
       centerOnHeroTimerIds: [],
       scrollClampFrameId: null,
       movePadStyle: {
@@ -80,157 +123,200 @@ export default {
       movePadFrameId: null,
       showMovePad: false,
       heroImage: randomGhostImage(),
+      showPortalDialog: false,
+      mapRevealed: false,
+      levelComplete: false,
     }
   },
   created() {
-    initLevel(this);
+    initLevel(this)
   },
 
   mounted() {
     if ('scrollRestoration' in window.history) {
-      window.history.scrollRestoration = 'manual';
+      window.history.scrollRestoration = 'manual'
     }
 
-    this.queueCenterOnHero();
-    this.updateMovePadVisibility();
-    this.updateMovePadPosition();
-    window.addEventListener('keydown', this.handleKeydown);
-    document.body.addEventListener('scroll', this.handleWindowScroll, { passive: true });
-    document.body.addEventListener('scroll', this.scheduleMovePadPositionUpdate, { passive: true });
-    window.addEventListener('resize', this.handleWindowScroll);
-    window.addEventListener('resize', this.updateMovePadVisibility);
-    window.addEventListener('resize', this.scheduleMovePadPositionUpdate);
-    window.addEventListener('load', this.queueCenterOnHero);
-    window.addEventListener('pageshow', this.queueCenterOnHero);
+    this.queueCenterOnHero()
+    this.updateMovePadVisibility()
+    this.updateMovePadPosition()
+    window.addEventListener('keydown', this.handleKeydown)
+    document.body.addEventListener('scroll', this.handleWindowScroll, { passive: true })
+    document.body.addEventListener('scroll', this.scheduleMovePadPositionUpdate, { passive: true })
+    window.addEventListener('resize', this.handleWindowScroll)
+    window.addEventListener('resize', this.updateMovePadVisibility)
+    window.addEventListener('resize', this.scheduleMovePadPositionUpdate)
+    window.addEventListener('load', this.queueCenterOnHero)
+    window.addEventListener('pageshow', this.queueCenterOnHero)
   },
 
   beforeUnmount() {
-    this.clearCenterOnHeroTimers();
-    this.cancelScrollClampFrame();
-    this.cancelMovePadPositionUpdate();
-    window.removeEventListener('keydown', this.handleKeydown);
-    document.body.removeEventListener('scroll', this.handleWindowScroll);
-    document.body.removeEventListener('scroll', this.scheduleMovePadPositionUpdate);
-    window.removeEventListener('resize', this.handleWindowScroll);
-    window.removeEventListener('resize', this.updateMovePadVisibility);
-    window.removeEventListener('resize', this.scheduleMovePadPositionUpdate);
-    window.removeEventListener('load', this.queueCenterOnHero);
-    window.removeEventListener('pageshow', this.queueCenterOnHero);
+    this.clearCenterOnHeroTimers()
+    this.cancelScrollClampFrame()
+    this.cancelMovePadPositionUpdate()
+    window.removeEventListener('keydown', this.handleKeydown)
+    document.body.removeEventListener('scroll', this.handleWindowScroll)
+    document.body.removeEventListener('scroll', this.scheduleMovePadPositionUpdate)
+    window.removeEventListener('resize', this.handleWindowScroll)
+    window.removeEventListener('resize', this.updateMovePadVisibility)
+    window.removeEventListener('resize', this.scheduleMovePadPositionUpdate)
+    window.removeEventListener('load', this.queueCenterOnHero)
+    window.removeEventListener('pageshow', this.queueCenterOnHero)
   },
 
   watch: {
     field() {
-      this.queueCenterOnHero();
+      this.queueCenterOnHero()
     },
   },
 
   methods: {
     centerOnHero() {
+      if (this.mapRevealed) return
+
       this.$nextTick(() => {
         setTimeout(() => {
-          scrollToPoint(this.heroX, this.heroY, this.cellSize);
-        }, 0);
-      });
+          scrollToPoint(this.heroX, this.heroY, this.cellSize)
+        }, 0)
+      })
     },
 
     clearCenterOnHeroTimers() {
-      this.centerOnHeroTimerIds.forEach((timerId) => window.clearTimeout(timerId));
-      this.centerOnHeroTimerIds = [];
+      this.centerOnHeroTimerIds.forEach((timerId) => window.clearTimeout(timerId))
+      this.centerOnHeroTimerIds = []
     },
 
     cancelScrollClampFrame() {
-      if (this.scrollClampFrameId === null) return;
-      window.cancelAnimationFrame(this.scrollClampFrameId);
-      this.scrollClampFrameId = null;
+      if (this.scrollClampFrameId === null) return
+      window.cancelAnimationFrame(this.scrollClampFrameId)
+      this.scrollClampFrameId = null
     },
 
     clampScrollPosition() {
-      clampScrollToBoardBounds();
+      clampScrollToBoardBounds()
     },
 
     handleWindowScroll() {
-      if (this.scrollClampFrameId !== null) return;
+      if (this.scrollClampFrameId !== null) return
 
       this.scrollClampFrameId = window.requestAnimationFrame(() => {
-        this.scrollClampFrameId = null;
-        this.clampScrollPosition();
-      });
+        this.scrollClampFrameId = null
+        this.clampScrollPosition()
+      })
     },
 
     queueCenterOnHero() {
-      if (!this.field) return;
+      if (!this.field) return
+      if (this.mapRevealed) return
 
-      this.clearCenterOnHeroTimers();
+      this.clearCenterOnHeroTimers()
 
-      [0, 100, 250, 500, 1000].forEach((delay) => {
+      ;[0, 100, 250, 500, 1000].forEach((delay) => {
         const timerId = window.setTimeout(() => {
-          this.centerOnHero();
-        }, delay);
+          this.centerOnHero()
+        }, delay)
 
-        this.centerOnHeroTimerIds.push(timerId);
-      });
+        this.centerOnHeroTimerIds.push(timerId)
+      })
     },
 
     cancelMovePadPositionUpdate() {
-      if (this.movePadFrameId === null) return;
-      window.cancelAnimationFrame(this.movePadFrameId);
-      this.movePadFrameId = null;
+      if (this.movePadFrameId === null) return
+      window.cancelAnimationFrame(this.movePadFrameId)
+      this.movePadFrameId = null
     },
 
     scheduleMovePadPositionUpdate() {
-      if (!this.showMovePad) return;
-      if (this.movePadFrameId !== null) return;
+      if (!this.showMovePad) return
+      if (this.movePadFrameId !== null) return
 
       this.movePadFrameId = window.requestAnimationFrame(() => {
-        this.movePadFrameId = null;
-        this.updateMovePadPosition();
-      });
+        this.movePadFrameId = null
+        this.updateMovePadPosition()
+      })
     },
 
     updateMovePadPosition() {
-      if (!this.showMovePad) return;
+      if (!this.showMovePad) return
 
-      const padSize = 56 * 3 + 8 * 2;
-      const insetRight = 20;
-      const insetBottom = 20;
-      const viewportWidth = document.documentElement.clientWidth;
-      const viewportHeight = document.documentElement.clientHeight;
-      const scrollLeft = document.body.scrollLeft;
-      const scrollTop = document.body.scrollTop;
-      const left = scrollLeft + viewportWidth - padSize - insetRight;
-      const top = scrollTop + viewportHeight - padSize - insetBottom;
+      const padSize = 56 * 3 + 8 * 2
+      const insetRight = 20
+      const insetBottom = 20
+      const viewportWidth = document.documentElement.clientWidth
+      const viewportHeight = document.documentElement.clientHeight
+      const scrollLeft = document.body.scrollLeft
+      const scrollTop = document.body.scrollTop
+      const left = scrollLeft + viewportWidth - padSize - insetRight
+      const top = scrollTop + viewportHeight - padSize - insetBottom
 
       this.movePadStyle = {
         left: `${Math.max(0, left)}px`,
         top: `${Math.max(0, top)}px`,
-      };
+      }
     },
 
     updateMovePadVisibility() {
+      if (this.levelComplete) {
+        this.showMovePad = false
+        return
+      }
+
       this.showMovePad = (
         window.matchMedia('(pointer: coarse)').matches
         || navigator.maxTouchPoints > 0
         || 'ontouchstart' in window
-      );
+      )
     },
 
     handleKeydown(e) {
       if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
-        return;
+        return
       }
 
-      e.preventDefault();
-      this.moveHero(e.key);
+      e.preventDefault()
+      this.moveHero(e.key)
     },
 
     moveHero(key) {
-      processKey(key, this);
-      this.heroImage = randomGhostImage();
-    }
+      if (this.levelComplete) return
+
+      const result = processKey(key, this)
+      this.heroImage = randomGhostImage()
+
+      if (result.reachedFinish) {
+        this.finishLevel()
+      }
+    },
+
+    finishLevel() {
+      this.levelComplete = true
+      this.showMovePad = false
+      this.heroSight = -1
+      setTimeout(() => {
+        this.showPortalDialog = true
+      }, consts.CELL_HIDE_DELAY)
+    },
+
+    revealMap() {
+      this.showPortalDialog = false
+      this.mapRevealed = true
+      this.$nextTick(() => {
+        this.clampScrollPosition()
+      })
+    },
+
+    carryOn() {
+      this.showPortalDialog = false
+      this.mapRevealed = false
+      this.levelComplete = false
+      initLevel(this, true)
+      this.heroImage = randomGhostImage()
+      this.updateMovePadVisibility()
+      this.queueCenterOnHero()
+    },
   },
 }
 </script>
-
 
 <style>
 @import './assets/base.css';
@@ -238,6 +324,24 @@ export default {
 main {
   touch-action: none;
   overscroll-behavior: none;
+}
+
+.main--revealed {
+  touch-action: auto;
+}
+
+.carry-on {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 9000;
+  padding: 10px 20px;
+  border-radius: 14px;
+  border: 1px solid rgba(188, 229, 255, 0.7);
+  background: rgba(16, 32, 58, 0.5);
+  color: #e8f5ff;
+  font-weight: 600;
+  backdrop-filter: blur(2px);
 }
 
 .move-pad {
@@ -309,5 +413,36 @@ main {
 
 .move-pad__arrow--left {
   transform: rotate(-135deg);
+}
+
+.portal-dialog-backdrop {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 99999;
+  background: rgba(3, 8, 18, 0.45);
+}
+
+.portal-dialog {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.portal-dialog__svg {
+  width: min(90vw, 520px);
+  height: auto;
+  filter: drop-shadow(0 18px 28px rgba(0, 0, 0, 0.35));
+}
+
+.portal-dialog__ok {
+  padding: 9px 28px;
+  border-radius: 999px;
+  border: 1px solid #84e2ff;
+  color: #e8f8ff;
+  background: linear-gradient(135deg, rgba(53, 125, 185, 0.95), rgba(96, 79, 209, 0.95));
+  font-weight: 700;
 }
 </style>

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -3,11 +3,23 @@
     <div class="cell_line" :style="`width: ${cellSize * width}px`" v-for="(line, y) in field">
       <template v-for="(cellType, x) in line">
         <Cell
-          :size=cellSize
-          :type=field[x][y]
-          :is-hidden="isHidden(x, y, heroX, heroY, heroSight)"
+          :size="cellSize"
+          :type="cellType"
+          :is-hidden="isHidden(x, y, heroX, heroY, effectiveSight)"
         />
       </template>
+    </div>
+    <div
+      v-if="showSoulTrack"
+      class="soul-track-overlay"
+      aria-hidden="true"
+    >
+      <div
+        v-for="(count, key) in soulTrack"
+        :key="key"
+        class="soul-track-cell"
+        :style="getTrackCellStyle(key, count)"
+      ></div>
     </div>
     <img class="board-hero" :src="heroImage"
       :style="`left: ${heroX * cellSize}px; top: ${heroY * cellSize}px; width: ${cellSize}px; height: ${cellSize}px;`">
@@ -15,10 +27,11 @@
 </template>
 
 <script setup>
+import { computed } from 'vue'
 import Cell from './Cell.vue'
 import { isHidden } from '../game/engine.js'
 
-defineProps({
+const props = defineProps({
   width: {
     type: Number,
     required: true,
@@ -28,7 +41,7 @@ defineProps({
     required: true,
   },
   field: {
-    type: Array[Array[String]],
+    type: Array,
     required: true,
   },
   heroX: {
@@ -50,20 +63,71 @@ defineProps({
   heroImage: {
     type: String,
     required: true,
-  }
+  },
+  revealMap: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
+  soulTrack: {
+    type: Object,
+    required: false,
+    default: () => ({}),
+  },
+  showSoulTrack: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 })
+
+const effectiveSight = computed(() => (props.revealMap ? Number.POSITIVE_INFINITY : props.heroSight))
+
+function getTrackCellStyle(key, count) {
+  const [x, y] = key.split(',').map(Number)
+  const lineCount = Math.min(Math.max(1, Number(count) || 1), 10)
+  const gradients = Array.from({ length: lineCount }, (_, idx) => {
+    const offset = idx * 4
+    const alpha = Math.min(0.2 + idx * 0.05, 0.75)
+    return `repeating-linear-gradient(45deg, transparent ${offset}px, rgba(153, 228, 255, ${alpha}) ${offset}px ${offset + 1.7}px, transparent ${offset + 1.7}px ${offset + 7}px)`
+  }).join(', ')
+
+  return {
+    left: `${x * props.cellSize}px`,
+    top: `${y * props.cellSize}px`,
+    width: `${props.cellSize}px`,
+    height: `${props.cellSize}px`,
+    backgroundImage: gradients,
+    opacity: 0.8,
+  }
+}
 </script>
 
 <style scoped>
-/* .board {
-  border: solid 2px;
-} */
 .cell_line {
   line-height: 0;
 }
+
+.board {
+  position: relative;
+}
+
 .board-hero {
   position: absolute;
   pointer-events: none;
-  z-index: 1;
+  z-index: 3;
+}
+
+.soul-track-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.soul-track-cell {
+  position: absolute;
+  border-radius: 8px;
+  mix-blend-mode: screen;
 }
 </style>

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -1,164 +1,221 @@
 import * as consts from './const.js'
 import { generateField, selectEmptyRandomCell } from './generator.js'
 
+const STORAGE_KEY = 'a-maze-ing-progress-v1'
 
 function isCellEmpty(field, width, height, x, y) {
-    if (x > width - 1 || x < 0 || y > height - 1 || y < 0 ) return false;
-    if (field[x][y] === 'wall') return false;
-    return true;
+  if (x > width - 1 || x < 0 || y > height - 1 || y < 0) return false
+  if (field[x][y] === 'wall') return false
+  return true
 }
 
 function isFinish(x, y, field) {
-    // console.log(x, y, field[x][y]);
-    return field[x][y] === 'finish';
+  return field[x][y] === 'finish'
 }
 
 function decreaseSight(data) {
-    // TODO: Make const for number of steps before sight decrease
-    if (data.stepCtr % 20 === 0 && data.heroSight >= 2) data.heroSight--;
+  if (data.stepCtr % 20 === 0 && data.heroSight >= 2) data.heroSight--
 }
 
 function processCell(data) {
-    switch (data.field[data.heroX][data.heroY]) {
-        case 'lamp':
-            data.heroSight = consts.INIT_SIGHT;
-            data.stepCtr = 0;
-        break;
+  switch (data.field[data.heroX][data.heroY]) {
+    case 'lamp':
+      data.heroSight = consts.INIT_SIGHT
+      data.stepCtr = 0
+      break
+  }
+}
+
+function incrementSoulTrack(data, x, y) {
+  if (!data.soulTrack) {
+    data.soulTrack = {}
+  }
+
+  const key = `${x},${y}`
+  data.soulTrack[key] = (data.soulTrack[key] ?? 0) + 1
+}
+
+function saveProgress(data) {
+  const payload = {
+    field: data.field,
+    heroX: data.heroX,
+    heroY: data.heroY,
+    heroSight: data.heroSight,
+    stepCtr: data.stepCtr,
+    soulTrack: data.soulTrack ?? {},
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+}
+
+function loadProgress(width, height) {
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return null
+
+  try {
+    const parsed = JSON.parse(raw)
+    const hasValidField = Array.isArray(parsed.field)
+      && parsed.field.length === width
+      && Array.isArray(parsed.field[0])
+      && parsed.field[0].length === height
+
+    if (!hasValidField) return null
+
+    return {
+      field: parsed.field,
+      heroX: parsed.heroX,
+      heroY: parsed.heroY,
+      heroSight: parsed.heroSight,
+      stepCtr: parsed.stepCtr,
+      soulTrack: parsed.soulTrack ?? {},
     }
+  } catch {
+    return null
+  }
 }
 
 function processKey(key, data) {
-    console.log('processKey', key);
-    let isMoved = false;
-    switch(key) {
-        case 'ArrowRight':
-            if (isCellEmpty(data.field, data.width, data.height, data.heroX + 1, data.heroY)) {
-                data.heroX += 1;
-                isMoved = true;
-            }
-        break;
-        case 'ArrowLeft':
-            if (isCellEmpty(data.field, data.width, data.height, data.heroX - 1, data.heroY)) {
-                data.heroX -= 1;
-                isMoved = true;
-            }
-        break;
-        case 'ArrowUp':
-            if (isCellEmpty(data.field, data.width, data.height, data.heroX, data.heroY - 1)) {
-                data.heroY -= 1;
-                isMoved = true;
-            }
-        break;
-        case 'ArrowDown':
-            if (isCellEmpty(data.field, data.width, data.height, data.heroX, data.heroY + 1)) {
-                data.heroY += 1;
-                isMoved = true;
-            }
-        break;
-    }
+  let isMoved = false
+  switch (key) {
+    case 'ArrowRight':
+      if (isCellEmpty(data.field, data.width, data.height, data.heroX + 1, data.heroY)) {
+        data.heroX += 1
+        isMoved = true
+      }
+      break
+    case 'ArrowLeft':
+      if (isCellEmpty(data.field, data.width, data.height, data.heroX - 1, data.heroY)) {
+        data.heroX -= 1
+        isMoved = true
+      }
+      break
+    case 'ArrowUp':
+      if (isCellEmpty(data.field, data.width, data.height, data.heroX, data.heroY - 1)) {
+        data.heroY -= 1
+        isMoved = true
+      }
+      break
+    case 'ArrowDown':
+      if (isCellEmpty(data.field, data.width, data.height, data.heroX, data.heroY + 1)) {
+        data.heroY += 1
+        isMoved = true
+      }
+      break
+  }
 
-    if (isMoved) {
-        scrollToPoint(data.heroX, data.heroY, data.cellSize);
-    }
+  if (isMoved) {
+    incrementSoulTrack(data, data.heroX, data.heroY)
+    scrollToPoint(data.heroX, data.heroY, data.cellSize)
+  }
 
-    // console.log(data.heroX, data.heroY);
-    data.stepCtr++;
-    decreaseSight(data);
-    // console.log(data.stepCtr, data.heroSight);
-    processCell(data);
-    if (isFinish(data.heroX, data.heroY, data.field)) {
-        data.heroSight = -1;  // to hide previous field
-        // TODO: Make field empty to hide previous one
-        setTimeout(() => {
-            alert('You found way out!');
-            initLevel(data);
-            scrollToPoint(data.heroX, data.heroY, data.cellSize);
-        }, consts.CELL_HIDE_DELAY);
-    }
+  data.stepCtr++
+  decreaseSight(data)
+  processCell(data)
+
+  const reachedFinish = isFinish(data.heroX, data.heroY, data.field)
+  saveProgress(data)
+
+  return {
+    isMoved,
+    reachedFinish,
+  }
 }
 
 function isHidden(x, y, heroX, heroY, heroSight) {
-    return Math.sqrt((heroX - x) * (heroX - x) + (heroY - y) * (heroY - y)) > heroSight
+  return Math.sqrt((heroX - x) * (heroX - x) + (heroY - y) * (heroY - y)) > heroSight
 }
 
 function clamp(value, min, max) {
-    return Math.min(Math.max(value, min), max);
+  return Math.min(Math.max(value, min), max)
 }
 
 function getScrollContainer() {
-    return document.body;
+  return document.body
 }
 
 function getViewportSize() {
-    return {
-        width: document.documentElement.clientWidth,
-        height: document.documentElement.clientHeight,
-    };
+  return {
+    width: document.documentElement.clientWidth,
+    height: document.documentElement.clientHeight,
+  }
 }
 
 function getBoardScrollLimits() {
-    const container = getScrollContainer();
-    const board = document.querySelector('.board');
-    const { width: viewportWidth, height: viewportHeight } = getViewportSize();
+  const container = getScrollContainer()
+  const board = document.querySelector('.board')
+  const { width: viewportWidth, height: viewportHeight } = getViewportSize()
 
-    if (!board) {
-        return {
-            viewportWidth,
-            viewportHeight,
-            maxScrollX: Math.max(0, container.scrollWidth - viewportWidth),
-            maxScrollY: Math.max(0, container.scrollHeight - viewportHeight),
-        };
-    }
-
-    const boardRect = board.getBoundingClientRect();
-    const boardLeft = boardRect.left + container.scrollLeft;
-    const boardTop = boardRect.top + container.scrollTop;
-
+  if (!board) {
     return {
-        viewportWidth,
-        viewportHeight,
-        maxScrollX: Math.max(0, boardLeft + board.scrollWidth - viewportWidth),
-        maxScrollY: Math.max(0, boardTop + board.scrollHeight - viewportHeight),
-    };
+      viewportWidth,
+      viewportHeight,
+      maxScrollX: Math.max(0, container.scrollWidth - viewportWidth),
+      maxScrollY: Math.max(0, container.scrollHeight - viewportHeight),
+    }
+  }
+
+  const boardRect = board.getBoundingClientRect()
+  const boardLeft = boardRect.left + container.scrollLeft
+  const boardTop = boardRect.top + container.scrollTop
+
+  return {
+    viewportWidth,
+    viewportHeight,
+    maxScrollX: Math.max(0, boardLeft + board.scrollWidth - viewportWidth),
+    maxScrollY: Math.max(0, boardTop + board.scrollHeight - viewportHeight),
+  }
 }
 
 function clampScrollToBoardBounds() {
-    const container = getScrollContainer();
-    const { maxScrollX, maxScrollY } = getBoardScrollLimits();
-    const targetX = clamp(container.scrollLeft, 0, maxScrollX);
-    const targetY = clamp(container.scrollTop, 0, maxScrollY);
+  const container = getScrollContainer()
+  const { maxScrollX, maxScrollY } = getBoardScrollLimits()
+  const targetX = clamp(container.scrollLeft, 0, maxScrollX)
+  const targetY = clamp(container.scrollTop, 0, maxScrollY)
 
-    if (targetX === container.scrollLeft && targetY === container.scrollTop) {
-        return;
-    }
+  if (targetX === container.scrollLeft && targetY === container.scrollTop) {
+    return
+  }
 
-    container.scrollTo(targetX, targetY);
+  container.scrollTo(targetX, targetY)
 }
 
 function scrollToPoint(x, y, cellSize) {
-    const container = getScrollContainer();
-    const { viewportWidth, viewportHeight, maxScrollX, maxScrollY } = getBoardScrollLimits();
-    const cellCenterX = x * cellSize + cellSize / 2;
-    const cellCenterY = y * cellSize + cellSize / 2;
-    const targetX = clamp(cellCenterX - viewportWidth / 2, 0, maxScrollX);
-    const targetY = clamp(cellCenterY - viewportHeight / 2, 0, maxScrollY);
+  const container = getScrollContainer()
+  const { viewportWidth, viewportHeight, maxScrollX, maxScrollY } = getBoardScrollLimits()
+  const cellCenterX = x * cellSize + cellSize / 2
+  const cellCenterY = y * cellSize + cellSize / 2
+  const targetX = clamp(cellCenterX - viewportWidth / 2, 0, maxScrollX)
+  const targetY = clamp(cellCenterY - viewportHeight / 2, 0, maxScrollY)
 
-    console.log('Scroll to:', targetX, targetY);
-    container.scrollTo(targetX, targetY);
+  container.scrollTo(targetX, targetY)
 }
 
-function initLevel(data) {
-    data.field = generateField(data.width, data.height);
-    [data.heroX, data.heroY] = selectEmptyRandomCell(data.field, data.width, data.height);
-    console.log('Hero:', data.heroX, data.heroY);
-    data.heroSight = consts.INIT_SIGHT;
-    data.stepCtr = 0;
+function initLevel(data, forceNewLevel = false) {
+  const saved = forceNewLevel ? null : loadProgress(data.width, data.height)
+
+  if (saved) {
+    data.field = saved.field
+    data.heroX = saved.heroX
+    data.heroY = saved.heroY
+    data.heroSight = saved.heroSight
+    data.stepCtr = saved.stepCtr
+    data.soulTrack = saved.soulTrack
+    return
+  }
+
+  data.field = generateField(data.width, data.height)
+  ;[data.heroX, data.heroY] = selectEmptyRandomCell(data.field, data.width, data.height)
+  data.heroSight = consts.INIT_SIGHT
+  data.stepCtr = 0
+  data.soulTrack = {}
+  incrementSoulTrack(data, data.heroX, data.heroY)
+  saveProgress(data)
 }
 
 export {
-    processKey,
-    isHidden,
-    scrollToPoint,
-    clampScrollToBoardBounds,
-    initLevel,
+  processKey,
+  isHidden,
+  scrollToPoint,
+  clampScrollToBoardBounds,
+  initLevel,
 }


### PR DESCRIPTION
### Motivation
- Replace blocking `alert` finish flow with a non-blocking portal dialog and explicit reveal/carry-on UX to improve end-of-level experience and accessibility. 
- Persist player progress (position, sight, step counter and a lightweight "soul track") so sessions can be resumed and the reveal state can show the full map without losing progress.  
- Surface a non-interactive visual trail of visited cells and keep rendering concerns in Vue components while putting persistence/movement logic in the engine.  

### Description
- Added portal/dialog UI and a "Carry on" action in `src/App.vue`, with new state flags `showPortalDialog`, `mapRevealed`, and `levelComplete`, plus methods `finishLevel`, `revealMap`, and `carryOn`.  
- Updated input/movement flow in `src/App.vue` to honor `levelComplete`/`mapRevealed`, avoid centering while map is revealed, and hide the move-pad when level is finished.  
- Extended `src/components/Board.vue` with new props `revealMap`, `soulTrack`, and `showSoulTrack`, added `effectiveSight` computed prop and a `soul-track` overlay renderer and styles to visualize visit counts.  
- Implemented persistence in `src/game/engine.js` with `STORAGE_KEY`, `saveProgress`, `loadProgress`, `incrementSoulTrack`, and updated `processKey` to track soul visits, save progress, and return `reachedFinish`; `initLevel` now restores saved state unless forced.  
- Added two skill docs `skills/frontend-endlevel-flow/SKILL.md` and `skills/project-checks/SKILL.md` describing the intended workflow and local checks.  

### Testing
- Ran `npm run build` and the build completed successfully with no build-time errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deaaa7fbbc83238f0dbe8889f87884)