### PR TITLE
Fix map/hero inconsistencies: align board rendering with engine and validate persisted state

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="board">
-    <div class="cell_line" :style="`width: ${cellSize * width}px`" v-for="(line, y) in field">
-      <template v-for="(cellType, x) in line">
+    <div class="cell_line" :style="`width: ${cellSize * width}px`" v-for="y in height" :key="`line-${y - 1}`">
+      <template v-for="x in width" :key="`cell-${x - 1}-${y - 1}`">
         <Cell
           :size="cellSize"
-          :type="cellType"
-          :is-hidden="isHidden(x, y, heroX, heroY, effectiveSight)"
+          :type="getCellType(x - 1, y - 1)"
+          :is-hidden="isHidden(x - 1, y - 1, heroX, heroY, effectiveSight)"
         />
       </template>
     </div>
@@ -100,6 +100,10 @@ function getTrackCellStyle(key, count) {
     backgroundImage: gradients,
     opacity: 0.8,
   }
+}
+
+function getCellType(x, y) {
+  return props.field?.[x]?.[y] ?? 'wall'
 }
 </script>
 

--- a/src/game/engine.js
+++ b/src/game/engine.js
@@ -5,8 +5,9 @@ const STORAGE_KEY = 'a-maze-ing-progress-v1'
 
 function isCellEmpty(field, width, height, x, y) {
   if (x > width - 1 || x < 0 || y > height - 1 || y < 0) return false
-  if (field[x][y] === 'wall') return false
-  return true
+  const cell = field?.[x]?.[y]
+  if (typeof cell !== 'string') return false
+  return cell !== 'wall'
 }
 
 function isFinish(x, y, field) {
@@ -56,10 +57,21 @@ function loadProgress(width, height) {
     const parsed = JSON.parse(raw)
     const hasValidField = Array.isArray(parsed.field)
       && parsed.field.length === width
-      && Array.isArray(parsed.field[0])
-      && parsed.field[0].length === height
+      && parsed.field.every((column) => Array.isArray(column) && column.length === height)
 
-    if (!hasValidField) return null
+    const hasValidHeroPosition = Number.isInteger(parsed.heroX)
+      && Number.isInteger(parsed.heroY)
+      && parsed.heroX >= 0
+      && parsed.heroX < width
+      && parsed.heroY >= 0
+      && parsed.heroY < height
+
+    const hasValidHeroSight = Number.isFinite(parsed.heroSight)
+    const hasValidStepCounter = Number.isInteger(parsed.stepCtr) && parsed.stepCtr >= 0
+
+    if (!hasValidField || !hasValidHeroPosition || !hasValidHeroSight || !hasValidStepCounter) {
+      return null
+    }
 
     return {
       field: parsed.field,


### PR DESCRIPTION
### Motivation
- Visual tiles could be shown in a different coordinate orientation than the game logic, causing characters to pass through walls or be blocked by visually-empty cells.
- Persisted progress in localStorage could be malformed after deploy/reload and was accepted permissively, enabling desynchronized map/hero state.
- The UI should always read the same `field[x][y]` layout the engine uses and corrupted saved state must fall back to generating a fresh level.

### Description
- Updated `src/components/Board.vue` to iterate visual rows/columns (`y` then `x`) and introduced `getCellType(x,y)` so the renderer reads cells using `field[x][y]` and falls back to `'wall'` for missing entries.
- Hardened collision checks in `src/game/engine.js` by making `isCellEmpty` validate the accessed cell (`typeof cell === 'string'`) and treat unknown/corrupt cells as blocked.
- Strengthened `loadProgress` validation in `src/game/engine.js` to verify full field shape (`every` column length), hero coordinates bounds, `heroSight` is finite, and `stepCtr` is a non-negative integer before restoring state.
- Behavior remains to regenerate and save a new level when stored state is invalid, and soul-track/save logic is preserved.

### Testing
- Built the production bundle with `npm run build` (Vite) and the build completed successfully producing `dist` assets.
- No automated test failures were reported during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deaf7500b083239cc46e23f53c3438)