### PR TITLE
Thought bubbles: dismiss on tap/X key and fix flipped text alignment

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,6 +30,7 @@
       :style="bubbleStylesById[bubble.id]"
       aria-live="polite"
       aria-atomic="true"
+      @pointerdown.prevent.stop="dismissThoughtBubble(bubble.id)"
     >
       <span class="thought-bubble__text">{{ bubble.text }}</span>
     </aside>
@@ -93,6 +94,8 @@ import {
   startThoughtBubbleLoop,
   stopThoughtBubbleLoop,
   resetThoughtState,
+  hideBubble as hideThoughtBubble,
+  hideOldestBubble as hideOldestThoughtBubble,
   onMove as onThoughtMove,
   onLevelComplete as onThoughtLevelComplete,
   onMapRevealed as onThoughtMapRevealed,
@@ -202,6 +205,7 @@ export default {
           top: `${Math.round(rect.top)}px`,
           '--bubble-flip-x': placement?.flipX ? -1 : 1,
           '--bubble-flip-y': placement?.flipY ? -1 : 1,
+          '--bubble-text-top-extra': placement?.flipY ? '10%' : '0%',
         }
       }
       return placements
@@ -603,6 +607,12 @@ export default {
     },
 
     handleKeydown(e) {
+      if (e.key.toLowerCase() === 'x') {
+        const hidden = hideOldestThoughtBubble(this)
+        if (hidden) e.preventDefault()
+        return
+      }
+
       if (!['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.key)) {
         return
       }
@@ -652,6 +662,10 @@ export default {
       this.queueCenterOnHero()
       resetThoughtState(this)
     },
+
+    dismissThoughtBubble(id) {
+      hideThoughtBubble(this, id)
+    },
   },
 }
 </script>
@@ -695,7 +709,8 @@ main {
   z-index: 8000;
   --bubble-flip-x: 1;
   --bubble-flip-y: 1;
-  pointer-events: none;
+  --bubble-text-top-extra: 0%;
+  pointer-events: auto;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -717,7 +732,7 @@ main {
   z-index: 1;
   display: block;
   width: 100%;
-  padding: 16% 15% 27% 15%;
+  padding: calc(16% + var(--bubble-text-top-extra)) 15% calc(27% - var(--bubble-text-top-extra)) 15%;
   box-sizing: border-box;
   color: rgba(0, 0, 0, 0.9);
   font-size: clamp(0.76rem, 1.6vw, 0.92rem);

--- a/src/game/__tests__/thoughtBubble.test.js
+++ b/src/game/__tests__/thoughtBubble.test.js
@@ -2,6 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   initialThoughtBubbleState,
+  hideBubble,
+  hideOldestBubble,
   onMove,
   onLevelComplete,
   onMapRevealed,
@@ -270,5 +272,52 @@ describe('bubble expiry by moves', () => {
 
     onMove(data) // moveCount becomes 3, 3 - 0 >= 3 → expire
     expect(data.thoughtBubbles.find((b) => b.id === 99)).toBeUndefined()
+  })
+})
+
+describe('manual bubble dismiss', () => {
+  it('hides bubble by id and clears its timer', () => {
+    const data = makeData()
+    const timerId = window.setTimeout(() => {}, 5000)
+    data.thoughtBubbles = [{
+      id: 5,
+      text: 'test',
+      slot: 'top-right',
+      group: 'test',
+      hideTimerId: timerId,
+      moveAtShow: 0,
+      maxMoves: 20,
+    }]
+
+    expect(hideBubble(data, 5)).toBe(true)
+    expect(data.thoughtBubbles).toHaveLength(0)
+  })
+
+  it('hides oldest displayed bubble', () => {
+    const data = makeData()
+    data.thoughtBubbles = [
+      {
+        id: 2,
+        text: 'newer',
+        slot: 'top-right',
+        group: 'test',
+        hideTimerId: null,
+        moveAtShow: 12,
+        maxMoves: 20,
+      },
+      {
+        id: 1,
+        text: 'older',
+        slot: 'top-left',
+        group: 'test',
+        hideTimerId: null,
+        moveAtShow: 3,
+        maxMoves: 20,
+      },
+    ]
+
+    expect(hideOldestBubble(data)).toBe(true)
+    expect(data.thoughtBubbles).toHaveLength(1)
+    expect(data.thoughtBubbles[0].id).toBe(2)
   })
 })

--- a/src/game/thoughtBubble.js
+++ b/src/game/thoughtBubble.js
@@ -166,6 +166,23 @@ export function onMapRevealed(data) {
   tryFireGroup(data, GROUPS.MAP_REVEALED)
 }
 
+export function hideBubble(data, id) {
+  return hideBubbleById(data, id)
+}
+
+export function hideOldestBubble(data) {
+  if (data.thoughtBubbles.length === 0) return false
+  const oldestBubble = data.thoughtBubbles.reduce((oldest, bubble) => {
+    if (!oldest) return bubble
+    if (bubble.moveAtShow !== oldest.moveAtShow) {
+      return bubble.moveAtShow < oldest.moveAtShow ? bubble : oldest
+    }
+    return bubble.id < oldest.id ? bubble : oldest
+  }, null)
+  if (!oldestBubble) return false
+  return hideBubbleById(data, oldestBubble.id)
+}
+
 // ============================================================
 // GROUP FIRING + COOLDOWN
 // ============================================================
@@ -301,10 +318,11 @@ function showBubble(data, candidates, group) {
 
 function hideBubbleById(data, id) {
   const idx = data.thoughtBubbles.findIndex((b) => b.id === id)
-  if (idx === -1) return
+  if (idx === -1) return false
   const bubble = data.thoughtBubbles[idx]
   if (bubble.hideTimerId !== null) window.clearTimeout(bubble.hideTimerId)
   data.thoughtBubbles.splice(idx, 1)
+  return true
 }
 
 function expireBubblesByMoves(data) {


### PR DESCRIPTION
### Motivation
- Vertically flipped thought bubbles placed the text too close to the top border, making it overlap the image; flipped bubbles need extra top inset only when `flipY` is active. 
- Players need a way to dismiss thought bubbles interactively (tap) and via keyboard (a single key to close the oldest bubble).

### Description
- Exported dismissal helpers from the thought bubble logic: added `hideBubble(data, id)` and `hideOldestBubble(data)` in `src/game/thoughtBubble.js` and made `hideBubbleById` return a boolean and clear the hide timer. 
- Wired UI interactions in `src/App.vue`: added a `@pointerdown` handler on each bubble to call `dismissThoughtBubble(id)`, added `dismissThoughtBubble` method that calls the new `hideBubble`, and added `X` key handling in `handleKeydown` to call `hideOldestBubble` for closing the oldest visible bubble. 
- Adjusted bubble layout CSS and computed styles: `bubbleStylesById` now sets a `--bubble-text-top-extra` variable when `flipY` is true, and `.thought-bubble__text` padding uses that variable to add top margin only for vertically flipped bubbles; also switched bubble `pointer-events` to allow taps. 
- Added unit tests in `src/game/__tests__/thoughtBubble.test.js` covering `hideBubble` and `hideOldestBubble` behavior.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `npm run test -- src/game/__tests__/thoughtBubble.test.js` but it failed in this environment with `vitest: not found`, so the new unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e118881ed483238f4163b843ca4345)