### PR TITLE
Edge-hide finish sequence: replace portal dialog with staged edge fade and cell delay

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
       :reveal-map="mapRevealed"
       :soul-path="soulPath"
       :show-soul-track="mapRevealed"
+      :edge-hide-sequence-active="edgeHideSequenceActive"
     />
     <button
       v-if="mapRevealed"
@@ -71,16 +72,6 @@
       </button>
     </div>
 
-    <div v-if="showPortalDialog" class="portal-dialog-backdrop">
-      <div class="portal-dialog" role="dialog" aria-modal="true" aria-label="Level complete">
-        <div class="portal-dialog__plate">
-          <h2 class="portal-dialog__title">Portal discovered</h2>
-          <p class="portal-dialog__body">Your soul remembers every step.</p>
-          <p class="portal-dialog__hint">Press OK to reveal the full map.</p>
-          <button type="button" class="brick-btn portal-dialog__ok" @click="revealMap">OK</button>
-        </div>
-      </div>
-    </div>
   </teleport>
 </template>
 
@@ -128,9 +119,10 @@ export default {
       movePadFrameId: null,
       showMovePad: false,
       heroImage: randomGhostImage(),
-      showPortalDialog: false,
       mapRevealed: false,
       levelComplete: false,
+      edgeHideSequenceActive: false,
+      edgeHideSequenceTimerId: null,
       carryOnBlink: false,
       carryOnBlinkTimerId: null,
       bubblePlacementById: {},
@@ -139,6 +131,9 @@ export default {
   },
   created() {
     initLevel(this)
+    if (this.isHeroOnPortalCell()) {
+      this.finishLevel(true)
+    }
   },
 
   mounted() {
@@ -179,6 +174,7 @@ export default {
     window.removeEventListener('pageshow', this.queueCenterOnHero)
     stopThoughtBubbleLoop(this)
     this.clearCarryOnBlinkTimer()
+    this.clearEdgeHideSequenceTimer()
     document.body.removeEventListener('scroll', this.resetCarryOnBlinkTimer)
     window.removeEventListener('pointerdown', this.resetCarryOnBlinkTimer)
   },
@@ -240,6 +236,16 @@ export default {
   },
 
   methods: {
+    isHeroOnPortalCell() {
+      return this.field?.[this.heroX]?.[this.heroY] === 'finish'
+    },
+
+    clearEdgeHideSequenceTimer() {
+      if (this.edgeHideSequenceTimerId === null) return
+      window.clearTimeout(this.edgeHideSequenceTimerId)
+      this.edgeHideSequenceTimerId = null
+    },
+
     rectsOverlap(a, b) {
       return !(a.right <= b.left || a.left >= b.right || a.bottom <= b.top || a.top >= b.bottom)
     },
@@ -633,18 +639,26 @@ export default {
       }
     },
 
-    finishLevel() {
+    finishLevel(isLoad = false) {
       this.levelComplete = true
       this.showMovePad = false
-      this.heroSight = -1
-      setTimeout(() => {
-        this.showPortalDialog = true
-        onThoughtLevelComplete(this)
-      }, consts.CELL_HIDE_DELAY)
+      this.edgeHideSequenceActive = true
+      onThoughtLevelComplete(this)
+      this.clearEdgeHideSequenceTimer()
+
+      const edgeLayers = Math.floor(Math.min(this.width, this.height) / 2)
+      const perLayerDelayMs = 24
+      const fadeDurationMs = 500
+      const sequenceDurationMs = edgeLayers * perLayerDelayMs + fadeDurationMs
+
+      this.edgeHideSequenceTimerId = window.setTimeout(() => {
+        this.edgeHideSequenceActive = false
+        this.edgeHideSequenceTimerId = null
+        this.revealMap()
+      }, isLoad ? Math.max(200, sequenceDurationMs * 0.5) : sequenceDurationMs)
     },
 
     revealMap() {
-      this.showPortalDialog = false
       this.mapRevealed = true
       onThoughtMapRevealed(this)
       this.$nextTick(() => {
@@ -653,7 +667,8 @@ export default {
     },
 
     carryOn() {
-      this.showPortalDialog = false
+      this.clearEdgeHideSequenceTimer()
+      this.edgeHideSequenceActive = false
       this.mapRevealed = false
       this.levelComplete = false
       initLevel(this, true)
@@ -813,52 +828,6 @@ main {
   transform: rotate(-135deg);
 }
 
-.portal-dialog-backdrop {
-  position: fixed;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  z-index: 99999;
-  background: rgba(3, 8, 18, 0.45);
-}
-
-.portal-dialog {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 14px;
-}
-
-.portal-dialog__plate {
-  width: min(90vw, 520px);
-  background: url('/images/plate.png') no-repeat center / 100% 100%;
-  aspect-ratio: 1317 / 687;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 12% 14%;
-}
-
-.portal-dialog__title {
-  color: #111;
-  font-size: clamp(1.1rem, 4vw, 1.8rem);
-  font-weight: 700;
-  margin: 0 0 0.4em;
-}
-
-.portal-dialog__body {
-  color: #333;
-  font-size: clamp(0.8rem, 2.5vw, 1rem);
-  margin: 0 0 0.3em;
-}
-
-.portal-dialog__hint {
-  color: #555;
-  font-size: clamp(0.7rem, 2vw, 0.9rem);
-  margin: 0;
-}
-
 .brick-btn {
   border: none;
   background: url('/images/brick_btn.png') no-repeat center / 100% 100%;
@@ -870,7 +839,4 @@ main {
   min-width: 120px;
 }
 
-.portal-dialog__ok {
-  margin-top: 0.6em;
-}
 </style>

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -5,7 +5,8 @@
         <Cell
           :size="cellSize"
           :type="getCellType(x - 1, y - 1)"
-          :is-hidden="isHidden(x - 1, y - 1, heroX, heroY, effectiveSight)"
+          :is-hidden="isCellHidden(x - 1, y - 1)"
+          :transition-delay-ms="getCellHideDelayMs(x - 1, y - 1)"
           :activated="x - 1 === heroX && y - 1 === heroY"
         />
       </template>
@@ -17,6 +18,30 @@
       :height="cellSize * height"
       aria-hidden="true"
     >
+      <g
+        v-if="trailStartDot"
+        class="trail-start-cross"
+        :transform="`translate(${trailStartDot.x}, ${trailStartDot.y})`"
+      >
+        <line
+          :x1="-startCrossHalfSize"
+          :y1="-startCrossHalfSize"
+          :x2="startCrossHalfSize"
+          :y2="startCrossHalfSize"
+          :stroke-width="startCrossStroke"
+          stroke="rgba(255, 72, 122, 0.95)"
+          stroke-linecap="round"
+        />
+        <line
+          :x1="-startCrossHalfSize"
+          :y1="startCrossHalfSize"
+          :x2="startCrossHalfSize"
+          :y2="-startCrossHalfSize"
+          :stroke-width="startCrossStroke"
+          stroke="rgba(255, 72, 122, 0.95)"
+          stroke-linecap="round"
+        />
+      </g>
       <circle
         v-for="(dot, i) in trailDots"
         :key="i"
@@ -85,6 +110,11 @@ const props = defineProps({
     required: false,
     default: false,
   },
+  edgeHideSequenceActive: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 })
 
 const effectiveSight = computed(() => (props.revealMap ? Number.POSITIVE_INFINITY : props.heroSight))
@@ -95,9 +125,31 @@ const trailDots = computed(() => {
 })
 
 const dotRadius = computed(() => Math.max(1.2, props.cellSize / 20))
+const trailStartDot = computed(() => trailDots.value[0] ?? null)
+const startCrossHalfSize = computed(() => Math.max(5, props.cellSize * 0.22))
+const startCrossStroke = computed(() => Math.max(2, props.cellSize * 0.1))
 
 function getCellType(x, y) {
   return props.field?.[x]?.[y] ?? 'wall'
+}
+
+function getEdgeRank(x, y) {
+  const left = x
+  const right = props.width - 1 - x
+  const top = y
+  const bottom = props.height - 1 - y
+  return Math.min(left, right, top, bottom)
+}
+
+function getCellHideDelayMs(x, y) {
+  if (!props.edgeHideSequenceActive) return 0
+  const stepDelayMs = 24
+  return getEdgeRank(x, y) * stepDelayMs
+}
+
+function isCellHidden(x, y) {
+  if (props.edgeHideSequenceActive) return true
+  return isHidden(x, y, props.heroX, props.heroY, effectiveSight.value)
 }
 </script>
 
@@ -122,5 +174,9 @@ function getCellType(x, y) {
   top: 0;
   pointer-events: none;
   z-index: 2;
+}
+
+.trail-start-cross {
+  filter: drop-shadow(0 0 6px rgba(255, 72, 122, 0.7));
 }
 </style>

--- a/src/components/Cell.vue
+++ b/src/components/Cell.vue
@@ -17,11 +17,23 @@ defineProps({
     required: false,
     default: false,
   },
+  transitionDelayMs: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
 })
 </script>
 
 <template>
-  <div :class="isHidden ? 'cell hidden' : 'cell'" :style="`width: ${size}px; height: ${size}px`">
+  <div
+    :class="isHidden ? 'cell hidden' : 'cell'"
+    :style="{
+      width: `${size}px`,
+      height: `${size}px`,
+      transitionDelay: `${Math.max(0, transitionDelayMs)}ms`,
+    }"
+  >
     <span v-if="type === 'lamp'" class="lamp-glow"></span>
     <img v-if="type === 'lamp' && activated" src="/images/glow.png">
     <img v-else-if="type !== 'empty'" :src="`/images/${type}.png`">


### PR DESCRIPTION
### Motivation
- Replace the modal portal dialog with a visual edge-hide sequence when a level completes, providing a smoother reveal animation before showing the full map.
- Ensure cells can participate in a staged hide animation by exposing per-cell transition delay values to the `Cell` component.
- Show a trail start marker on the board overlay and automatically complete a level when loading if the hero is already on the portal cell.

### Description
- Removed the portal dialog markup and related CSS and instead introduced an `edgeHideSequenceActive` boolean and `edgeHideSequenceTimerId` in `App.vue` to orchestrate the finish animation and deferred reveal logic.
- Updated `finishLevel` to trigger the edge hide sequence, compute a per-layer sequence duration, and call `revealMap` after the sequence (with a shortened delay when finishing on load via `finishLevel(true)`).
- Added `isHeroOnPortalCell` and `clearEdgeHideSequenceTimer` helpers in `App.vue`, and ensured timers are cleared on `beforeUnmount` and when carrying on a level.
- `Board.vue` now accepts `edgeHideSequenceActive`, computes `getEdgeRank` and `getCellHideDelayMs`, exposes `trailStartDot` and start-cross sizing, and passes per-cell hide delays and an updated hidden state via `:is-hidden="isCellHidden(...)"` and `:transition-delay-ms` props.
- `Cell.vue` gained a `transitionDelayMs` prop and applies `transitionDelay` inline so individual cells can stagger their opacity transitions.
- Added a start-cross SVG marker for the first soul-trail dot and related scoped styling.

### Testing
- Ran the project unit test suite with `npm test`, and the tests completed successfully.
- Ran the linter with `npm run lint`, and no linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e11bd68d0c8323a2e73635f3e1d607)