### PR TITLE
Fade soul image before cell-hide cascade on level finish

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@
       :reveal-map="game.mapRevealed"
       :soul-path="game.soulPath"
       :show-soul-track="game.mapRevealed"
+      :soul-fade-sequence-active="soulFadeSequenceActive"
       :edge-hide-sequence-active="edgeHideSequenceActive"
     />
     <CarryOnButton :visible="game.mapRevealed" @click="carryOn" />
@@ -78,11 +79,13 @@ const game = reactive({
 const { width: viewportWidth, height: viewportHeight } = useViewportSize()
 const heroImage = ref(randomGhostImage())
 const showPortalDialog = ref(false)
+const soulFadeSequenceActive = ref(false)
 const edgeHideSequenceActive = ref(false)
 const bubblePlacementById = ref({})
 
 let scrollClampFrameId = null
 let centerOnHeroTimerIds = []
+let soulFadeSequenceTimerId = null
 let edgeHideSequenceTimerId = null
 
 const cellSize = computed(() => {
@@ -140,6 +143,12 @@ function clearEdgeHideSequenceTimer() {
   if (edgeHideSequenceTimerId === null) return
   window.clearTimeout(edgeHideSequenceTimerId)
   edgeHideSequenceTimerId = null
+}
+
+function clearSoulFadeSequenceTimer() {
+  if (soulFadeSequenceTimerId === null) return
+  window.clearTimeout(soulFadeSequenceTimerId)
+  soulFadeSequenceTimerId = null
 }
 
 function centerOnHero() {
@@ -215,14 +224,23 @@ function moveHero(key) {
 
 function finishLevel(isLoad = false) {
   game.levelComplete = true
-  edgeHideSequenceActive.value = true
+  soulFadeSequenceActive.value = true
+  edgeHideSequenceActive.value = false
   onThoughtLevelComplete(game)
+  clearSoulFadeSequenceTimer()
   clearEdgeHideSequenceTimer()
 
+  const soulFadeDurationMs = 420
   const edgeLayers = Math.floor(Math.min(game.width, game.height) / 2)
   const perLayerDelayMs = 24
   const fadeDurationMs = 500
-  const sequenceDurationMs = edgeLayers * perLayerDelayMs + fadeDurationMs
+  const hideCellsDelayMs = isLoad ? Math.floor(soulFadeDurationMs * 0.5) : soulFadeDurationMs
+  const sequenceDurationMs = hideCellsDelayMs + edgeLayers * perLayerDelayMs + fadeDurationMs
+
+  soulFadeSequenceTimerId = window.setTimeout(() => {
+    soulFadeSequenceTimerId = null
+    edgeHideSequenceActive.value = true
+  }, hideCellsDelayMs)
 
   edgeHideSequenceTimerId = window.setTimeout(() => {
     edgeHideSequenceTimerId = null
@@ -235,6 +253,7 @@ function finishLevel(isLoad = false) {
 
 function confirmRevealMap() {
   showPortalDialog.value = false
+  soulFadeSequenceActive.value = false
   edgeHideSequenceActive.value = false
   revealMap()
 }
@@ -248,7 +267,9 @@ function revealMap() {
 }
 
 function carryOn() {
+  clearSoulFadeSequenceTimer()
   clearEdgeHideSequenceTimer()
+  soulFadeSequenceActive.value = false
   edgeHideSequenceActive.value = false
   showPortalDialog.value = false
   game.mapRevealed = false
@@ -298,6 +319,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('load', queueCenterOnHero)
   window.removeEventListener('pageshow', queueCenterOnHero)
   stopThoughtBubbleLoop(game)
+  clearSoulFadeSequenceTimer()
   clearEdgeHideSequenceTimer()
 })
 

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -17,6 +17,7 @@ const props = defineProps({
   revealMap: { type: Boolean, default: false },
   soulPath: { type: Array, default: () => [] },
   showSoulTrack: { type: Boolean, default: false },
+  soulFadeSequenceActive: { type: Boolean, default: false },
   edgeHideSequenceActive: { type: Boolean, default: false },
 })
 
@@ -71,7 +72,10 @@ function isCellHidden(x, y) {
       :width="width"
       :height="height"
     />
-    <img v-if="!revealMap" class="board-hero" :src="heroImage"
+    <img
+      v-if="!revealMap"
+      :class="['board-hero', { 'board-hero--fading': soulFadeSequenceActive }]"
+      :src="heroImage"
       :style="`left: ${heroX * cellSize}px; top: ${heroY * cellSize}px; width: ${cellSize}px; height: ${cellSize}px;`">
   </div>
 </template>
@@ -90,5 +94,11 @@ function isCellHidden(x, y) {
   position: absolute;
   pointer-events: none;
   z-index: 3;
+  opacity: 1;
+  transition: opacity 0.42s ease-out;
+}
+
+.board-hero--fading {
+  opacity: 0;
 }
 </style>


### PR DESCRIPTION
### Motivation
- Make the end-of-level animation sequence visually correct by fading the soul image first, then running the existing edge cell hide cascade so the hero disappears before cells vanish. 
- Use the `frontend-endlevel-flow` skill for implementing UI/state changes and `project-checks` for local validation of the change.

### Description
- Add a new `soulFadeSequenceActive` reactive flag in `src/App.vue` and pass it into `Board` as a prop to control the soul/hero fading phase. 
- Trigger the soul fade when finishing a level and start the existing edge-hide cascade only after a delay equal to the soul fade duration, using a dedicated timeout (`soulFadeSequenceTimerId`).
- Add timer cleanup helpers and call them from carry-on/unmount paths to avoid stale timers (`clearSoulFadeSequenceTimer`).
- Update `src/components/Board.vue` to apply a `board-hero--fading` CSS class and an `opacity` transition so the soul image visually fades out before cells hide.

### Testing
- Ran `npm run build`, which failed in this environment due to missing `vite` (`sh: 1: vite: not found`).
- Ran `git status --short` which completed successfully.
- Ran `git diff -- src/App.vue src/components/Board.vue src/game/engine.js` which completed successfully and shows the described changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfaf6b4908323a09c658473f17d64)